### PR TITLE
make `utils` accessible via `JSO.utils`

### DIFF
--- a/src/jso.js
+++ b/src/jso.js
@@ -46,6 +46,7 @@ define(function(require, exports, module) {
 	JSO.internalStates = [];
 	JSO.instances = {};
 	JSO.store = store;
+	JSO.utils = utils;
 
 	console.log("RESET internalStates array");
 


### PR DESCRIPTION
Makes JSO users can easily leverage existing utility functions.