### PR TITLE
Adding skipRedirect config option to prevent changing the URL hash

### DIFF
--- a/README-getting-started.md
+++ b/README-getting-started.md
@@ -73,6 +73,7 @@ Here are more options to JSO:
 * `scope`: For providers that does not support `state`: If state was not provided, and default provider contains a scope parameter we assume this is the one requested... Set this as the same list of scopes that you provide to `ensure_tokens`.
 * `scopes.request`: Control what scopes are requested in the authorization request.
 * `debug`: If debug is set to true, verbose logging will make it easier to debug problems with JSO.
+* `skipRedirect`: If skipRedirect is set to true, JSO will not change the hash after handling an access token.
 
 
 ## Catching the response when the user is returning

--- a/build/jso.js
+++ b/build/jso.js
@@ -1056,10 +1056,8 @@ define('jso',['require','exports','module','./store','./utils','./Config'],funct
 
 		store.saveToken(state.providerID, atoken);
 
-		if (state.restoreHash) {
-			window.location.hash = state.restoreHash;
-		} else {
-			window.location.hash = '';
+		if (!this.config.get('skipRedirect', null)) {
+			window.location.hash = state.restoreHash || '';
 		}
 
 
@@ -1077,7 +1075,7 @@ define('jso',['require','exports','module','./store','./utils','./Config'],funct
 		utils.log("Successfully obtain a token, now call the callback, and may be the window closes", callback);
 
 		if (typeof callback === 'function') {
-			callback(atoken);
+			callback(atoken, state.restoreHash || '');
 		}
 
 		// utils.log(atoken);

--- a/src/jso.js
+++ b/src/jso.js
@@ -254,10 +254,8 @@ define(function(require, exports, module) {
 
 		store.saveToken(state.providerID, atoken);
 
-		if (state.restoreHash) {
-			window.location.hash = state.restoreHash;
-		} else {
-			window.location.hash = '';
+		if (!this.config.get('skipRedirect', null)) {
+			window.location.hash = state.restoreHash || '';
 		}
 
 
@@ -275,7 +273,7 @@ define(function(require, exports, module) {
 		utils.log("Successfully obtain a token, now call the callback, and may be the window closes", callback);
 
 		if (typeof callback === 'function') {
-			callback(atoken);
+			callback(atoken, state.restoreHash || '');
 		}
 
 		// utils.log(atoken);


### PR DESCRIPTION
Adding skipRedirect config option to prevent changing the URL hash (redirecting) after the access token is handled.