### PR TITLE
Adding /build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 misc.txt
 bower_components
+/build


### PR DESCRIPTION
Adding /build to .gitignore, so build artifacts must be explicitly added to be tracked by git (like build/jso.js).

Supports the removal of other files from 879b90.
