### PR TITLE
Update "Getting Started" to propose a way of you using a CDN

### DIFF
--- a/README-getting-started.md
+++ b/README-getting-started.md
@@ -20,7 +20,13 @@ Preferrably you may obtain JSO using [bower.io](http://bower.io).
 
 Alternatively, you may obtain the source from github by downloading or cloning the source.
 
-Currently, JSO is not available through any CDN.
+### Using a CDN
+
+If you like to use it with a CDN the recommended way is to use it through [rawgit.com](https://rawgit.com).
+
+Simply paste [the build path](https://github.com/andreassolberg/jso/blob/master/build/jso.js) in rawgit.com and you are good to go !
+
+
 
 
 ## Loading JSO


### PR DESCRIPTION
RawGit gives the ability to act as a CDN directly from Github , this is very usefull when you don't have CDN to publish to.