### PR TITLE
Use rfc6749 to standardize authorization code feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ In the config include these parameters:
 
 ```
 	response_type: 'code',
-	client_secret: "xxxxx-xxxx-xxx-xxx",
+	client_secret: "xxxxx-xxxx-xxx-xxx", (if necessary)
 	token: "https://auth.dataporten.no/oauth/token",
 ```
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,41 @@ In the config include these parameters:
 	token: "https://auth.dataporten.no/oauth/token",
 ```
 
+To resolve async issue after authorization, use `then()` method to return a Promise:
+
+```
+client.callback().then(callback => {
+    let token = null;
+    
+    if (callback) {
+      token = callback;
+      console.log('I got the token', token);
+
+    } else {
+      client.getToken().then(tokenFromStore => {
+        token = tokenFromStore;
+        console.log('I got the token', token);
+      });
+    }
+  });
+```
+
+You can use async function and the `await` keyword:
+```
+async function MyFunction() {
+  let token = null;
+  const callback = await client.callback();
+
+  if (callback) {
+    token = callback;
+  } else {
+    token = await client.getToken();
+  }
+
+  console.log('I got the token', token);
+}
+```
+
 Also be aware that the implementation of this flow uses `fetch`, to support older browser you would need to polyfill that.
 
 

--- a/src/JSO.js
+++ b/src/JSO.js
@@ -173,7 +173,8 @@ class JSO extends EventEmitter {
 		if (object.state) {
 			state = this.store.getState(object.state)
       if (state === null) {
-        throw new Error("Could not find retrieve state object.")
+        utils.log("Could not find retrieve state object.")
+        return
       }
 		} else {
 			throw new Error("Could not find state paramter from callback.")

--- a/src/JSO.js
+++ b/src/JSO.js
@@ -166,7 +166,6 @@ class JSO extends EventEmitter {
 
   // Experimental support for authorization code to be added
   processAuthorizationCodeResponse(object) {
-    console.log(this)
     this.emit('authorizationCode', object)
 
 
@@ -179,22 +178,23 @@ class JSO extends EventEmitter {
 		} else {
 			throw new Error("Could not find state paramter from callback.")
 		}
-    console.log("state", state)
 
     if (!this.config.has('token')) {
       utils.log("Received an authorization code. Will not process it as the config option [token] endpoint is not set. If you would like to process the code yourself, please subscribe to the [authorizationCode] event")
       return
     }
-    if (!this.config.has('client_secret')) {
-      throw new Error("Configuration missing [client_secret]")
-    }
+
     let headers = new Headers()
-    headers.append('Authorization', 'Basic ' + btoa(this.config.getValue('client_id') + ":" + this.config.getValue('client_secret')))
     headers.append('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8')
 
     let tokenRequest = {
       'grant_type': 'authorization_code',
-      'code': object.code
+      'code': object.code,
+      'client_id': this.config.getValue('client_id')
+    }
+
+    if (this.config.has('client_secret')) {
+      tokenRequest.client_secret = this.config.getValue('client_secret')
     }
 
     if (state.hasOwnProperty('redirect_uri')) {
@@ -209,6 +209,17 @@ class JSO extends EventEmitter {
     }
     return fetch(this.config.getValue('token'), opts)
       .then((httpResponse) => {
+        if (!httpResponse.ok) {
+          if (httpResponse.status === 401) {
+            throw Error(
+              'Unauthorized: it lacks valid authentication credentials for the target resource. ' + httpResponse.statusText
+            );
+          } else {
+            throw Error(
+              httpResponse.status + ' could not get a token for the target resource'
+            );
+          }
+        }
         return httpResponse.json()
       })
       .then((tokenResponse) => {

--- a/src/JSO.js
+++ b/src/JSO.js
@@ -295,7 +295,10 @@ class JSO extends EventEmitter {
 
 		} else if (response.hasOwnProperty("error")) {
 			throw this.processErrorResponse(response)
-		}
+
+    } else if (this.config.has('token')) {
+      return Promise.resolve()
+    }
 
 	}
 


### PR DESCRIPTION
Currently, OAuth 2.0 Authorization Code flow is an experimental feature and doesn't use the good way to process the authorization code response.

Indeed, append a header `Authorization` with an encoding in base64 `client_id`+ `client_secret` doesn't work if the server which hosts the token endpoint follow the standards.

- - -

So, this commit follow the [rfc6749](https://tools.ietf.org/html/rfc6749#section-4.1) and standardize authorization code feature. 

Moreover, `client_secret` is not required during the access token request. However, if the token endpoint ask it, the dev' just add it in the configuration and it will be automatically add in the parameters.


**Edit**: To resolve async issue on `callback` function (See issue https://github.com/andreassolberg/jso/issues/103), we return a `Promise` instead of `undefined`. Documentation has been improved in this way.

**Edit 2**: Sometimes, an user can keep `code` and `state` in the url parameters. JSO throw an error but in most of cases, tokens & authorization are ok. Now, we just log a line said it could not find retrieve state object.